### PR TITLE
Fixed npm install + updates

### DIFF
--- a/blueprints/ember-leaflet-polyline-decorator/index.js
+++ b/blueprints/ember-leaflet-polyline-decorator/index.js
@@ -1,6 +1,6 @@
 /*jshint node:true*/
 module.exports = {
-  description: ''
+  description: '',
 
   // locals: function(options) {
   //   // Return custom template variables here.

--- a/blueprints/ember-leaflet-polyline-decorator/index.js
+++ b/blueprints/ember-leaflet-polyline-decorator/index.js
@@ -1,15 +1,10 @@
 /*jshint node:true*/
 module.exports = {
-  description: '',
+  description: 'add leaflet-polylinedecorator, using npm',
 
-  // locals: function(options) {
-  //   // Return custom template variables here.
-  //   return {
-  //     foo: options.entity.options.foo
-  //   };
-  // }
-
-  afterInstall: function(options) {
-    return this.addBowerPackageToProject('leaflet-polylinedecorator', '^1.1.0');
+  normalizeEntityName: function() {}, // no-op since we're just adding dependencies
+  
+  afterInstall: function() {
+    return this.addPackageToProject('leaflet-polylinedecorator', '^1.2.0'); // Add's a package to the project's package.json
   }
 };

--- a/blueprints/ember-leaflet-polyline-decorator/index.js
+++ b/blueprints/ember-leaflet-polyline-decorator/index.js
@@ -10,6 +10,6 @@ module.exports = {
   // }
 
   afterInstall: function(options) {
-    return this.addBowerPackageToProject('leaflet-polylinedecorator', 'bbecquet/Leaflet.PolylineDecorator');
+    return this.addBowerPackageToProject('leaflet-polylinedecorator', '^1.1.0');
   }
 };

--- a/blueprints/ember-leaflet-polyline-decorator/index.js
+++ b/blueprints/ember-leaflet-polyline-decorator/index.js
@@ -10,6 +10,6 @@ module.exports = {
   // }
 
   afterInstall: function(options) {
-    return this.addBowerPackageToProject('leaflet-polylinedecorator', 'bbecquet/Leaflet.PolylineDecorator#^leaflet-0.7.2');
+    return this.addBowerPackageToProject('leaflet-polylinedecorator', 'bbecquet/Leaflet.PolylineDecorator');
   }
 };

--- a/bower.json
+++ b/bower.json
@@ -3,9 +3,6 @@
   "dependencies": {
     "ember": "~2.6.0",
     "ember-cli-shims": "0.1.1",
-    "ember-cli-test-loader": "0.2.2",
-    "ember-qunit-notifications": "0.1.0",
-    "leaflet": "^1.0.3",
-    "leaflet-polylinedecorator": "^1.1.0"
+    "ember-cli-test-loader": "0.2.2"
   }
 }

--- a/bower.json
+++ b/bower.json
@@ -5,7 +5,7 @@
     "ember-cli-shims": "0.1.1",
     "ember-cli-test-loader": "0.2.2",
     "ember-qunit-notifications": "0.1.0",
-    "leaflet": "~0.7.2",
-    "leaflet-polylinedecorator": "bbecquet/Leaflet.PolylineDecorator#leaflet-0.7.2"
+    "leaflet": "^1.0.3",
+    "leaflet-polylinedecorator": "^1.1.0"
   }
 }

--- a/index.js
+++ b/index.js
@@ -1,9 +1,41 @@
 /* jshint node: true */
 'use strict';
+const resolve = require('resolve');
+const path = require('path');
+const Funnel = require('broccoli-funnel');
 
 module.exports = {
   name: 'ember-leaflet-polyline-decorator',
+
+  treeForVendor: function() {
+    let dist = path.join(this.pathBase('leaflet-polylinedecorator'), 'dist');
+    return new Funnel(dist, { destDir: 'leaflet-polylinedecorator' });
+  },
+
   included: function(app) {
-    app.import(app.bowerDirectory + '/leaflet-polylinedecorator/leaflet.polylineDecorator.js');
+    this._super.included.apply(this, arguments);
+
+    // If the addon has the _findHost() method (in ember-cli >= 2.7.0), we'll just
+    // use that.
+    if (typeof this._findHost === 'function') {
+      app = this._findHost();
+    }
+
+    // Otherwise, we'll use this implementation borrowed from the _findHost()
+    // method in ember-cli.
+    // Keep iterating upward until we don't have a grandparent.
+    // Has to do this grandparent check because at some point we hit the project.
+    var current = this;
+    do {
+     app = current.app || app;
+    } while (current.parent.parent && (current = current.parent));
+
+    var baseDir = 'vendor/leaflet-polylinedecorator/';
+    
+    app.import(baseDir + 'leaflet.polylineDecorator.js'); // Import the javascript into the app
+  },
+
+  pathBase: function(packageName) {
+    return path.dirname(resolve.sync(packageName + '/package.json', { basedir: __dirname }));
   }
 };

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@transitland/ember-leaflet-polyline-decorator",
+  "name": "ember-leaflet-polyline-decorator",
   "version": "0.1.0",
   "description": "An Ember-CLI addon for using the Leaflet Polyline Decorator plugin.",
   "directories": {

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "ember-load-initializers": "^0.5.1",
     "ember-resolver": "^2.0.3",
     "ember-welcome-page": "^1.0.1",
-    "ember-leaflet": "2.2.7",
+    "ember-leaflet": "3.0.12",
     "loader.js": "^4.0.1"
   },
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -26,7 +26,6 @@
     "ember-cli": "2.6.1",
     "ember-cli-app-version": "^1.0.0",
     "ember-cli-dependency-checker": "^1.2.0",
-    "ember-cli-htmlbars": "^1.0.3",
     "ember-cli-htmlbars-inline-precompile": "^0.3.1",
     "ember-cli-inject-live-reload": "^1.4.0",
     "ember-cli-jshint": "^1.0.0",
@@ -37,10 +36,9 @@
     "ember-data": "^2.6.0",
     "ember-disable-prototype-extensions": "^1.1.0",
     "ember-export-application-global": "^1.0.5",
+    "ember-leaflet": "^3.0.12",
     "ember-load-initializers": "^0.5.1",
     "ember-resolver": "^2.0.3",
-    "ember-welcome-page": "^1.0.1",
-    "ember-leaflet": "3.0.12",
     "loader.js": "^4.0.1"
   },
   "keywords": [
@@ -50,8 +48,11 @@
     "leaflet"
   ],
   "dependencies": {
+    "broccoli-funnel": "^1.1.0",
     "ember-cli-babel": "^5.1.6",
-    "ember-cli-htmlbars": "^1.0.8"
+    "ember-cli-htmlbars": "^1.3.3",
+    "leaflet": "~1.1.0",
+    "leaflet-polylinedecorator": "~1.2.0"
   },
   "ember-addon": {
     "configPath": "tests/dummy/config"

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
   ],
   "dependencies": {
     "ember-cli-babel": "^5.1.6",
-    "ember-cli-htmlbars": "1.0.8"
+    "ember-cli-htmlbars": "^1.0.8"
   },
   "ember-addon": {
     "configPath": "tests/dummy/config"


### PR DESCRIPTION
This PR should fix the npm install issues mentioned here https://github.com/transitland/ember-leaflet-polyline-decorator/issues/1

leaflet and leaflet-polylinedecorator and other dependencies are now pulled in with npm.

I also updated the package versions for most of these dependencies to much later versions.

I have also renamed the package from `@transitland/ember-leaflet-polyline-decorator` to just `ember-leaflet-polyline-decorator` to keep it consistent with other ember-leaflet addon names (feel free to override this if you don't want the package name changed - I am not sure how this affects npm publishing)

Once this PR is pulled in I'll make another PR with an updated readme with basic instructions on usage & installation with npm

I haven't really messed with ember addons before this so while I think I did everything correctly, I could have missed something (but it seems to work for me now)