### PR TITLE
Polyline decorator now updates when supplied patterns object changes

### DIFF
--- a/addon/components/polyline-decorator.js
+++ b/addon/components/polyline-decorator.js
@@ -12,5 +12,32 @@ export default BaseLayer.extend({
 
   createLayer() {
     return this.L.polylineDecorator(this.get('requiredOptions'), this.get('options'));
+  },
+
+  didInsertParent() {
+    this._super(...arguments);
+    this._addPatternObserver();
+  },
+
+  willDestroyParent() {
+    this._removePatternObserver();
+    this._super(...arguments);
+  },
+  
+  // Observe for when patterns option changes, so the decorator can be redrawn with the new pattern
+  _addPatternObserver() {
+    this._patternObserver = null;
+    
+    this._patternObserver = function() {
+      let value = this.get('patterns');
+      this._layer.setPatterns(value);
+    };
+
+    this.addObserver('patterns', this, this._patternObserver);
+  },
+
+  _removePatternObserver() {
+    this.removeObserver('patterns', this, this._patternObserver);
+    this._patternObserver = null;
   }
 });


### PR DESCRIPTION
Observer added for 'patterns' arg of the polyline-decorator component

```handlebars
{{polyline-decorator latlngs=locations patterns=linePatterns}}
```

Doing this will now cause the polyline-decorator to update its pattern
```javascript
this.set('linePatterns',newPattern);
```